### PR TITLE
Fixed assert properties inconsistencies

### DIFF
--- a/validation_schemas/abstract_patterns/v11/bestand/bestand_bevat_nlcs_objecten.sch
+++ b/validation_schemas/abstract_patterns/v11/bestand/bestand_bevat_nlcs_objecten.sch
@@ -9,13 +9,13 @@
 
         <assert id="file-has-aprojectreferentie"
             test="count($aprojectreferenties) = 1"
-            properties="rule-number">
+            properties="rule-number severity">
             <value-of select="keronic:get-translation('aprojectreferentie-not-present')"/>
         </assert>
 
         <assert id="file-has-nlcs-objects"
             test="count($nlcs_objects) > 0"
-            properties="scope rule-number severity">
+            properties="rule-number severity">
             <value-of select="keronic:get-translation('no-nlcs-objects-present')"/>
         </assert>
     </rule>

--- a/validation_schemas/abstract_patterns/v11/geometrie/lijn_geometrie-afstand_van_inmeetpunten.sch
+++ b/validation_schemas/abstract_patterns/v11/geometrie/lijn_geometrie-afstand_van_inmeetpunten.sch
@@ -37,7 +37,7 @@
 
           <assert id="line-geometry-line-segments-meet-length-demand"
                test="empty($line_segments_not_meeting_length_demands)"
-               properties="rule-number object-type object-id geometries">
+               properties="scope rule-number severity object-type object-id geometries">
                <value-of select="keronic:get-translation('line-segment-measurement-incorrect')"/>
           </assert>
      </rule>
@@ -79,7 +79,7 @@
 
           <assert id="area-geometry-line-segments-meet-length-demand"
                test="empty($line_segments_not_meeting_length_demands)"
-               properties="scope rule-number severity object-type object-id">
+               properties="scope rule-number severity object-type object-id geometries">
                <value-of select="keronic:get-translation('line-segment-measurement-incorrect')"/>
           </assert>
      </rule>

--- a/validation_schemas/abstract_patterns/v11/inhoud_waarde/mantelbuis_past_in_mantelbuis.sch
+++ b/validation_schemas/abstract_patterns/v11/inhoud_waarde/mantelbuis_past_in_mantelbuis.sch
@@ -12,7 +12,7 @@
 
         <assert id="mantelbuis_inhoud_fits_in_mantelbuis"
             test="not(keronic:element-exists-and-not-empty($inhoud_diameter)) or upper-case($inhoud_diameter) = 'KEUZE ONTBREEKT IN LIJST' or (nlcs:Diameter > $inhoud_diameter)"
-            properties="scope rule-number object-type object-id">
+            properties="scope rule-number severity object-type object-id">
             <value-of select="keronic:get-translation-and-replace-placeholders(
                 'mantelbuis-inhoud-diameter-larger-than-own',
                 [nlcs:Diameter, $inhoud_diameter])"/>


### PR DESCRIPTION
All assert properties now the same (scope, rule-number, severity, object-type, object-id), except for R.1 (just rule-number and severity) and R.4 (added geometries)